### PR TITLE
Fix launch script and improve host executable discovery

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -18,34 +18,28 @@ if [ ! -d "/Library/Audio/Plug-Ins/HAL/RadioformDriver.driver" ]; then
     exit 1
 fi
 
+# Kill any existing instances first
+pkill -f RadioformHost 2>/dev/null
+pkill -f RadioformApp 2>/dev/null
+sleep 1
+
 # Always restart coreaudiod to ensure fresh state
 # This fixes various audio routing and device initialization issues
 echo "Restarting coreaudiod for clean audio state..."
 sudo killall coreaudiod
 sleep 3
 
-# Verify driver loaded
-PROXY_DEVICES=$(system_profiler SPAudioDataType 2>/dev/null | grep -c "Radioform" || echo "0")
+# Note: Radioform devices won't appear until the host starts and creates the control file
+# The host will be started by the menu bar app, so we don't check for devices here
 
-if [ "$PROXY_DEVICES" -eq "0" ]; then
-    echo "❌ No Radioform devices found!"
-    echo "   The driver may not be installed correctly."
-    echo ""
-    echo "Try running: ./setup.sh"
-    exit 1
-else
-    echo "✓ Driver loaded ($PROXY_DEVICES proxy device(s) found)"
-    echo ""
-fi
-
-# Kill any existing instances
-pkill -f RadioformHost 2>/dev/null
-pkill -f RadioformApp 2>/dev/null
-
-sleep 1
-
-# Launch the menu bar app (it will auto-launch the host)
+# Launch the menu bar app (it will auto-launch the host, which creates the control file)
 echo "Starting menu bar app..."
+echo "   (Radioform devices will appear once the host starts)"
+echo ""
+
+# Set environment variable so app can find the host executable
+export RADIOFORM_ROOT="$(pwd)"
+
 apps/mac/RadioformApp/.build/debug/RadioformApp
 
 echo ""

--- a/setup.sh
+++ b/setup.sh
@@ -9,7 +9,11 @@ echo ""
 
 # Build DSP library
 echo "1. Building DSP library..."
-cd packages/dsp/build
+cd packages/dsp
+if [ ! -d "build" ]; then
+    mkdir -p build
+fi
+cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release
 make
 cd ../../..


### PR DESCRIPTION
- Fix launch.sh to not check for devices before host starts (devices are created by host)
- Fix setup.sh to create build directory before running cmake
- Improve RadioformApp to dynamically find RadioformHost executable:
  - Search multiple possible locations (relative paths, home directory, env var)
  - Handle architecture-specific build directories (arm64-apple-macosx)
  - Support both release and debug builds
- Set RADIOFORM_ROOT environment variable in launch.sh for reliable host discovery
- Remove hardcoded user paths in favor of dynamic discovery