### PR TITLE
UI improvements: standardized padding, improved preset dropdown, and …

### DIFF
--- a/apps/mac/RadioformApp/Sources/App/RadioformApp.swift
+++ b/apps/mac/RadioformApp/Sources/App/RadioformApp.swift
@@ -36,7 +36,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Create popover with menu content
         popover = NSPopover()
-        popover?.contentSize = NSSize(width: 300, height: 400)
+        popover?.contentSize = NSSize(width: 340, height: 600) // Larger height to accommodate expanded presets
         popover?.behavior = .transient
         popover?.contentViewController = NSHostingController(rootView: MenuBarView())
     }


### PR DESCRIPTION
…hover states

- Removed Radioform title from header
- Standardized horizontal padding across all sections (20px for header/EQ, 8px for presets)
- Changed preset dropdown from popover to inline expandable list
- Updated hover states to use native Swift colors (separatorColor)
- Preset button shows blue fill when active and EQ is enabled
- Selected preset is excluded from dropdown list
- Improved toggle behavior to reapply preset when turning EQ back on
- Consistent padding between preset dropdown button and list items