### PR TITLE
fix: move SSE headers to file scope for Linux compatibility

### DIFF
--- a/packages/dsp/src/cpu_util.h
+++ b/packages/dsp/src/cpu_util.h
@@ -8,6 +8,12 @@
 
 #include <cstdint>
 
+// Include platform-specific headers at file scope
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
+    #include <xmmintrin.h>  // SSE
+    #include <pmmintrin.h>  // SSE3 for DAZ
+#endif
+
 namespace radioform {
 
 /**
@@ -23,9 +29,6 @@ namespace radioform {
 inline void enable_denormal_suppression() {
 #if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
     // x86/x86_64: Use SSE control register
-    #include <xmmintrin.h>  // SSE
-    #include <pmmintrin.h>  // SSE3 for DAZ
-
     // Flush-to-zero (FTZ): underflow results become zero
     _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
 
@@ -56,9 +59,6 @@ inline void enable_denormal_suppression() {
  */
 inline void disable_denormal_suppression() {
 #if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
-    #include <xmmintrin.h>
-    #include <pmmintrin.h>
-
     _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_OFF);
     _MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_OFF);
 


### PR DESCRIPTION
The SSE intrinsics headers (xmmintrin.h, pmmintrin.h) were being included inside function bodies, which causes compilation errors on Linux GCC. Moved them to file scope at the top of cpu_util.h.

This fixes CI build failures on x86_64-linux-gnu while maintaining compatibility with macOS ARM64.