### PR TITLE
Implement precise slider dragging

### DIFF
--- a/apps/mac/RadioformApp/Sources/Services/PresetManager.swift
+++ b/apps/mac/RadioformApp/Sources/Services/PresetManager.swift
@@ -385,6 +385,9 @@ class PresetManager: ObservableObject {
         applyCurrentStateToAudio()
     }
 
+    /// Round dB level to 1 decimal place (reflecting how dB values are formatted in the UI)
+    private func roundDb(_ db: Float) -> Float { (db * 10).rounded() / 10 }
+
     /// Apply current state to audio, throttled to prevent IPC flooding during rapid updates
     private func applyCurrentStateToAudio() {
         // Throttle: coalesce rapid calls (drag, scroll) into one IPC write per ~30ms
@@ -400,7 +403,7 @@ class PresetManager: ObservableObject {
             let gain = enabled ? currentBands[index] : 0.0
             return EQBand(
                 frequencyHz: frequency,
-                gainDb: gain,
+                gainDb: roundDb(gain),
                 qFactor: currentQFactors[index],
                 filterType: currentFilterTypes[index],
                 enabled: abs(gain) > 0.01

--- a/apps/mac/RadioformApp/Sources/Views/TenBandEQ.swift
+++ b/apps/mac/RadioformApp/Sources/Views/TenBandEQ.swift
@@ -205,6 +205,8 @@ struct VerticalSlider: View {
                             .foregroundColor(.primary.opacity(0.8))
                             .lineLimit(1)
                             .minimumScaleFactor(0.7)
+                            // Reduce horizontal text movement when dragging
+                            .monospacedDigit()
                     }
                 }
                 .frame(width: knobSize, height: knobSize)

--- a/apps/mac/RadioformApp/Sources/Views/TenBandEQ.swift
+++ b/apps/mac/RadioformApp/Sources/Views/TenBandEQ.swift
@@ -68,9 +68,9 @@ struct TenBandEQ: View {
 
                             // Frequency label
                             Text(index == 10 ? "Pre" : formatFrequency(presetManager.currentFrequencies[index]))
-                                .font(.system(size: 9))
-                                .foregroundColor(index == 10 ? .accentColor.opacity(0.7) : .secondary)
-                                .frame(minWidth: 22)
+                            .font(.system(size: 9))
+                            .foregroundColor(index == 10 ? .accentColor.opacity(0.7) : .secondary)
+                            .frame(minWidth: 22)
                         }
                         .padding(.horizontal, 3)
 
@@ -114,6 +114,18 @@ struct VerticalSlider: View {
 
     private let normalKnobSize: CGFloat = 16
     private let focusedKnobSize: CGFloat = 22
+
+    // While dragging, if the user moves the cursor horizontally beyond this threshold, the dB levels will be adjusted more precisely
+    private let preciseThresholdX: Float = 50
+    // Multiplier that allows for fine-grained dB adjustments 
+    private let preciseFactor: Float = 0.05
+
+    // Remember the drag Y value so we can maintain the slider position when shifting to precise mode
+    @State private var prevDragY: CGFloat? = nil
+
+    // Used for the knob border to reflect the current dragging mode
+    @State private var isDragging: Bool = false
+    @State private var isPreciseDrag: Bool = false
 
     private var knobSize: CGFloat {
         isFocused ? focusedKnobSize : normalKnobSize
@@ -172,8 +184,17 @@ struct VerticalSlider: View {
                         .overlay(
                             Circle()
                                 .stroke(
-                                    isFocused ? Color.accentColor.opacity(0.6) : Color(NSColor.separatorColor).opacity(0.8),
-                                    lineWidth: isFocused ? 1.0 : 0.5
+                                    (isFocused
+                                        ? isDragging
+                                            ? Color.white
+                                            : Color.accentColor.opacity(0.6)
+                                        : Color(NSColor.separatorColor).opacity(0.8)),
+                                    style: StrokeStyle(
+                                        lineWidth: isFocused ? 1 : 0.5,
+
+                                        // Dotted border indicates precise dragging mode
+                                        dash: isDragging && isPreciseDrag ? [2, 2] : []
+                                    )
                                 )
                         )
 
@@ -198,9 +219,36 @@ struct VerticalSlider: View {
                 .gesture(
                     DragGesture(minimumDistance: 1)
                         .onChanged { gesture in
-                            let newValue = 1 - (gesture.location.y / geometry.size.height)
-                            let clampedValue = max(0, min(1, newValue))
-                            value = range.lowerBound + Float(clampedValue) * (range.upperBound - range.lowerBound)
+                            let rangeSpan = range.upperBound - range.lowerBound
+                            let knobCenterX = Float(geometry.size.width / 2)
+                            let mouseDistanceX = abs(Float(gesture.location.x) - knobCenterX)
+                            let multiplier: Float = mouseDistanceX > preciseThresholdX ? preciseFactor : 1
+
+                            isDragging = true
+                            isPreciseDrag = mouseDistanceX > preciseThresholdX
+
+                            if prevDragY == nil {
+                                let newValue = 1 - (gesture.location.y / geometry.size.height)
+                                let clampedValue = max(0, min(1, newValue))
+
+                                value = range.lowerBound + Float(clampedValue) * rangeSpan
+                                prevDragY = gesture.translation.height
+                            } else {
+                                // Vertical difference from the previous drag position
+                                let deltaY = Float(gesture.translation.height - (prevDragY ?? gesture.translation.height))
+
+                                prevDragY = gesture.translation.height
+
+                                let progress = -deltaY / Float(geometry.size.height)
+                                let valueIncrement = progress * rangeSpan * multiplier
+
+                                value = min(max(range.lowerBound, value + valueIncrement), range.upperBound)
+                            }
+                        }
+                        .onEnded { _ in
+                            isDragging = false
+                            isPreciseDrag = false
+                            prevDragY = nil
                         }
                 )
             }

--- a/apps/mac/RadioformApp/Sources/Views/TenBandEQ.swift
+++ b/apps/mac/RadioformApp/Sources/Views/TenBandEQ.swift
@@ -234,18 +234,17 @@ struct VerticalSlider: View {
                                 let clampedValue = max(0, min(1, newValue))
 
                                 value = range.lowerBound + Float(clampedValue) * rangeSpan
-                                prevDragY = gesture.translation.height
                             } else {
                                 // Vertical difference from the previous drag position
-                                let deltaY = Float(gesture.translation.height - (prevDragY ?? gesture.translation.height))
-
-                                prevDragY = gesture.translation.height
+                                let deltaY = Float(gesture.translation.height - (prevDragY ?? gesture.translation.height))                                
 
                                 let progress = -deltaY / Float(geometry.size.height)
                                 let valueIncrement = progress * rangeSpan * multiplier
 
                                 value = min(max(range.lowerBound, value + valueIncrement), range.upperBound)
                             }
+
+                            prevDragY = gesture.translation.height
                         }
                         .onEnded { _ in
                             isDragging = false


### PR DESCRIPTION
My first PR here 😅 As mentioned in #58, adjusting dB values by `.1` can be quite difficult as it can require very fine precision. This PR adds precise dragging which is activated when moving horizontally away from the slider while dragging. This pattern is found in the native iOS video player, however I have only added a single "precise" mode rather than dynamically adjusting it depending on the distance from the slider as it didn't seem necessary for this use case.

While working on this, I also made some other changes which are not strictly necessary for this PR:

- Round decibel values when applying the EQ bands - it seemed like it might not be clear to the user that the dB values were being saved with more than 1 decimal place. This keeps the internal EQ bands consistent with the UI which renders `n.n dB` to the user.
- Use tabular numerals for displaying the slider dB values - since this value gets updated rapidly when sliding up and down, it results in the text jumping around horizontally since the widths of each number are different. This uses the font's built-in tabular variant to avoid this. (https://sebastiandedeyne.com/tabular-numbers)

I want to mention that I did use AI assistance when coding this mainly when updating the drag `onChanged` handler as I am not very familiar with SwiftUI. Even so, I verified its output and rewrote several parts by-hand once I was happy with the approach.


https://github.com/user-attachments/assets/a7e9e6e2-871f-43be-be37-99eb3eac0059

