### PR TITLE
feat: add AutoEQ preset import

### DIFF
--- a/apps/mac/RadioformApp/Sources/Services/AutoEQParser.swift
+++ b/apps/mac/RadioformApp/Sources/Services/AutoEQParser.swift
@@ -1,0 +1,149 @@
+import Foundation
+
+/// Parses AutoEQ ParametricEQ.txt files into Radioform EQPresets.
+/// Supports files from AutoEQ (GitHub), squig.link, and Equalizer APO format.
+enum AutoEQParser {
+
+    enum ParseError: LocalizedError {
+        case emptyFile
+        case noFiltersFound
+        case tooManyFilters
+
+        var errorDescription: String? {
+            switch self {
+            case .emptyFile: return "File is empty"
+            case .noFiltersFound: return "No EQ filters found in file"
+            case .tooManyFilters: return "File contains more than 20 filters"
+            }
+        }
+    }
+
+    /// Parse an AutoEQ .txt file and return an EQPreset.
+    /// - Parameters:
+    ///   - content: Raw text content of the file
+    ///   - name: Preset name (typically derived from filename)
+    /// - Returns: A valid EQPreset ready to save/apply
+    static func parse(content: String, name: String) throws -> EQPreset {
+        let lines = content
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .components(separatedBy: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+
+        guard !lines.isEmpty else { throw ParseError.emptyFile }
+
+        var preampDb: Float = 0.0
+        var bands: [EQBand] = []
+
+        for line in lines {
+            if let preamp = parsePreampLine(line) {
+                preampDb = preamp
+            } else if let band = parseFilterLine(line) {
+                bands.append(band)
+            }
+        }
+
+        guard !bands.isEmpty else { throw ParseError.noFiltersFound }
+        guard bands.count <= 20 else { throw ParseError.tooManyFilters }
+
+        // If more than 10 bands, keep the 10 with the highest impact (absolute gain)
+        if bands.count > 10 {
+            bands.sort { abs($0.gainDb) > abs($1.gainDb) }
+            bands = Array(bands.prefix(10))
+            // Re-sort by frequency for consistent display
+            bands.sort { $0.frequencyHz < $1.frequencyHz }
+        }
+
+        // Clamp preamp to Radioform's range
+        preampDb = max(-12.0, min(12.0, preampDb))
+
+        // Truncate name to 64 chars
+        let presetName = String(name.prefix(64))
+
+        return EQPreset(
+            name: presetName,
+            bands: bands,
+            preampDb: preampDb,
+            limiterEnabled: true,
+            limiterThresholdDb: -0.1
+        )
+    }
+
+    // MARK: - Line Parsers
+
+    /// Parse "Preamp: -6.4 dB" → Float
+    private static func parsePreampLine(_ line: String) -> Float? {
+        let pattern = #"^Preamp:\s*([-\d.]+)\s*dB"#
+        guard let match = line.range(of: pattern, options: .regularExpression) else { return nil }
+        let matched = String(line[match])
+        // Extract the number
+        let numPattern = #"[-\d.]+"#
+        guard let numRange = matched.range(of: numPattern, options: .regularExpression) else { return nil }
+        return Float(String(matched[numRange]))
+    }
+
+    /// Parse "Filter 1: ON PK Fc 105 Hz Gain 6.5 dB Q 0.70" → EQBand
+    private static func parseFilterLine(_ line: String) -> EQBand? {
+        let pattern = #"^Filter\s+\d+:\s+(ON|OFF)\s+(\S+)\s+Fc\s+([\d.]+)\s+Hz\s+Gain\s+([-\d.]+)\s+dB(?:\s+Q\s+([\d.]+))?"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+        let nsLine = line as NSString
+        guard let match = regex.firstMatch(in: line, range: NSRange(location: 0, length: nsLine.length)) else { return nil }
+
+        // Group 1: ON/OFF
+        let enabledStr = nsLine.substring(with: match.range(at: 1))
+        let enabled = enabledStr == "ON"
+
+        // Group 2: Filter type
+        let typeStr = nsLine.substring(with: match.range(at: 2))
+        let filterType = mapFilterType(typeStr)
+
+        // Group 3: Frequency
+        guard let freq = Float(nsLine.substring(with: match.range(at: 3))) else { return nil }
+
+        // Group 4: Gain
+        guard let gain = Float(nsLine.substring(with: match.range(at: 4))) else { return nil }
+
+        // Group 5: Q (optional, default 0.707 for shelf filters, 1.0 for peak)
+        var q: Float = filterType == .peak ? 1.0 : 0.707
+        if match.range(at: 5).location != NSNotFound {
+            if let parsedQ = Float(nsLine.substring(with: match.range(at: 5))) {
+                q = parsedQ
+            }
+        }
+
+        // Clamp to Radioform's valid ranges
+        let clampedFreq = max(20.0, min(20000.0, freq))
+        let clampedGain = max(-12.0, min(12.0, gain))
+        let clampedQ = max(0.1, min(10.0, q))
+
+        return EQBand(
+            frequencyHz: clampedFreq,
+            gainDb: clampedGain,
+            qFactor: clampedQ,
+            filterType: filterType,
+            enabled: enabled
+        )
+    }
+
+    /// Map AutoEQ filter type strings to Radioform FilterType
+    private static func mapFilterType(_ type: String) -> FilterType {
+        switch type.uppercased() {
+        case "PK", "PEQ", "MODAL":
+            return .peak
+        case "LS", "LSC", "LSQ", "LS 6DB", "LS 12DB":
+            return .lowShelf
+        case "HS", "HSC", "HSQ", "HS 6DB", "HS 12DB":
+            return .highShelf
+        case "LP", "LPQ":
+            return .lowPass
+        case "HP", "HPQ":
+            return .highPass
+        case "NO":
+            return .notch
+        case "BP":
+            return .bandPass
+        default:
+            return .peak
+        }
+    }
+}

--- a/apps/mac/RadioformApp/Sources/Services/PresetManager.swift
+++ b/apps/mac/RadioformApp/Sources/Services/PresetManager.swift
@@ -638,6 +638,32 @@ class PresetManager: ObservableObject {
         isEditingPresetName = false
     }
 
+    /// Import an AutoEQ .txt file as a user preset
+    func importAutoEQ(from url: URL) throws -> EQPreset {
+        let content = try String(contentsOf: url, encoding: .utf8)
+
+        // Derive preset name from filename (strip extension)
+        let baseName = url.deletingPathExtension().lastPathComponent
+            // Clean up common AutoEQ suffixes
+            .replacingOccurrences(of: " ParametricEQ", with: "")
+            .replacingOccurrences(of: " Filters", with: "")
+            .replacingOccurrences(of: "ParametricEQ", with: "Imported")
+            .trimmingCharacters(in: .whitespaces)
+        let name = baseName.isEmpty ? "Imported EQ" : baseName
+        let uniqueName = generateUniqueName(name)
+
+        let preset = try AutoEQParser.parse(content: content, name: uniqueName)
+
+        // Save as user preset
+        try savePreset(preset)
+
+        // Return the saved version (reloaded with fresh UUID)
+        if let saved = userPresets.first(where: { $0.name == uniqueName }) {
+            return saved
+        }
+        return preset
+    }
+
     /// Sanitize filename (remove invalid characters)
     private func sanitizeFilename(_ name: String) -> String {
         var safe = name.replacingOccurrences(of: "/", with: "-")

--- a/apps/mac/RadioformApp/Sources/Views/MenuBarView.swift
+++ b/apps/mac/RadioformApp/Sources/Views/MenuBarView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UniformTypeIdentifiers
 
 // Cache font lookup once at launch
 private let radioformFont: Font = {
@@ -384,7 +385,7 @@ struct PresetList: View {
     let userPresetIDs: Set<EQPreset.ID>
     let onSelect: (EQPreset) -> Void
     let onDelete: (EQPreset) -> Void
-    
+
     // Max items to show before scrolling (each item ~40px + 2px spacing)
     private let maxVisibleItems = 13
     private let estimatedItemHeight: CGFloat = 40
@@ -405,9 +406,80 @@ struct PresetList: View {
                         onDelete: onDelete
                     )
                 }
+
+                ImportAutoEQButton(onImport: { preset in
+                    onSelect(preset)
+                })
             }
         }
         .frame(maxHeight: presets.count > maxVisibleItems ? maxHeight : nil)
+    }
+}
+
+struct ImportAutoEQButton: View {
+    let onImport: (EQPreset) -> Void
+    @State private var isHovered = false
+    @State private var importError: String?
+
+    var body: some View {
+        Button {
+            importFile()
+        } label: {
+            HStack(spacing: 10) {
+                ZStack {
+                    Circle()
+                        .fill(Color(NSColor.separatorColor).opacity(0.4))
+                        .frame(width: 28, height: 28)
+
+                    Image(systemName: "square.and.arrow.down")
+                        .font(.system(size: 13, weight: .medium))
+                        .symbolRenderingMode(.hierarchical)
+                        .foregroundStyle(.secondary)
+                }
+
+                Text(importError ?? "Import AutoEQ")
+                    .font(.system(size: 13))
+                    .foregroundColor(importError != nil ? .red : .primary)
+
+                Spacer()
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 4)
+            .contentShape(Rectangle())
+            .background(
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(isHovered ? Color(NSColor.separatorColor).opacity(0.5) : Color.clear)
+            )
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, 4)
+        .padding(.vertical, 2)
+        .onHover { hovering in
+            isHovered = hovering
+        }
+    }
+
+    private func importFile() {
+        importError = nil
+
+        let panel = NSOpenPanel()
+        panel.title = "Import AutoEQ Preset"
+        panel.allowedContentTypes = [.plainText]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        do {
+            let preset = try PresetManager.shared.importAutoEQ(from: url)
+            onImport(preset)
+        } catch {
+            importError = error.localizedDescription
+            // Clear error after 3 seconds
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                importError = nil
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Adds AutoEQ `.txt` file import, as requested in #58.

- **AutoEQParser** (`Services/AutoEQParser.swift`): Parses `ParametricEQ.txt` files from AutoEQ, squig.link, and Equalizer APO format. Handles preamp lines, filter lines (PK, LSC, HSC, LS, HS, LP, HP, NO, BP, etc.), optional Q values, CRLF/LF line endings, and ON/OFF filter states. Clamps all values to Radioform's valid ranges. If >10 filters, keeps the 10 with highest absolute gain.
- **PresetManager.importAutoEQ** (`Services/PresetManager.swift`): Reads file, derives preset name from filename (strips common suffixes like "ParametricEQ" and "Filters"), generates unique name, saves as user preset.
- **Import button** (`Views/MenuBarView.swift`): "Import AutoEQ" button at the bottom of the preset list. Opens `NSOpenPanel` for `.txt` file selection, imports and immediately applies the preset. Shows error inline for 3 seconds if parsing fails.

### How it works

1. User clicks "Import AutoEQ" in the preset dropdown
2. File picker opens for `.txt` files
3. Parser reads the file, maps AutoEQ filter types to Radioform's `FilterType` enum, and creates an `EQPreset`
4. Preset is saved to `~/Library/Application Support/Radioform/Presets/` and applied immediately

### Format support

Tested against the standard AutoEQ format:
```
Preamp: -6.4 dB
Filter 1: ON LSC Fc 105 Hz Gain 6.5 dB Q 0.70
Filter 2: ON PK Fc 7620 Hz Gain 3.8 dB Q 0.57
...
```

Also handles squig.link variations (CRLF line endings, 3-decimal Q values, LSQ/HSQ types).

## Test plan

- [ ] Import a standard AutoEQ `ParametricEQ.txt` file (e.g., Sennheiser HD 600)
- [ ] Import a squig.link export (`.txt` with CRLF line endings)
- [ ] Verify imported preset appears in user presets list
- [ ] Verify EQ bands, frequencies, Q factors, and filter types are correctly applied
- [ ] Verify preamp value is set correctly
- [ ] Try importing a non-EQ `.txt` file — should show "No EQ filters found" error
- [ ] Import a file with >10 filters — should keep top 10 by gain impact
- [ ] Delete an imported preset — should work like any user preset

Closes #58