### PR TITLE
feat: add AutoEQ support

### DIFF
--- a/apps/mac/RadioformApp/Sources/Services/AutoEQIndex.swift
+++ b/apps/mac/RadioformApp/Sources/Services/AutoEQIndex.swift
@@ -1,0 +1,148 @@
+import Foundation
+
+struct AutoEQEntry: Identifiable {
+    let id = UUID()
+    let name: String
+    let path: String
+    let source: String
+
+    var parametricEQURL: URL? {
+        let filename = "\(name) ParametricEQ.txt"
+        let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? path
+        let encodedFile = filename.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? filename
+        return URL(string: "https://raw.githubusercontent.com/jaakkopasanen/AutoEq/master/results/\(encodedPath)/\(encodedFile)")
+    }
+}
+
+/// Fetches and searches the AutoEQ headphone index from GitHub
+class AutoEQIndex: ObservableObject {
+    static let shared = AutoEQIndex()
+
+    @Published var entries: [AutoEQEntry] = []
+    @Published var isLoading = false
+    @Published var error: String?
+
+    private var lastFetchDate: Date?
+    private let cacheURL: URL
+
+    private init() {
+        let appSupport = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first!
+        let radioformDir = appSupport.appendingPathComponent("Radioform")
+        try? FileManager.default.createDirectory(
+            at: radioformDir, withIntermediateDirectories: true)
+        cacheURL = radioformDir.appendingPathComponent("autoeq-index.txt")
+    }
+
+    func search(_ query: String) -> [AutoEQEntry] {
+        guard !query.isEmpty else { return [] }
+        let lowered = query.lowercased()
+        return Array(entries
+            .filter { $0.name.lowercased().contains(lowered) }
+            .prefix(50))
+    }
+
+    func loadIfNeeded() {
+        if !entries.isEmpty {
+            if let lastFetch = lastFetchDate, Date().timeIntervalSince(lastFetch) > 86400 {
+                fetchFromNetwork()
+            }
+            return
+        }
+
+        if let cached = loadCache() {
+            entries = cached
+            return
+        }
+
+        fetchFromNetwork()
+    }
+
+    func fetchProfile(_ entry: AutoEQEntry) async throws -> String {
+        guard let url = entry.parametricEQURL else {
+            throw URLError(.badURL)
+        }
+        let (data, response) = try await URLSession.shared.data(from: url)
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            throw URLError(.badServerResponse)
+        }
+        guard let content = String(data: data, encoding: .utf8) else {
+            throw URLError(.cannotDecodeContentData)
+        }
+        return content
+    }
+
+    // MARK: - Private
+
+    private func fetchFromNetwork() {
+        guard !isLoading else { return }
+        isLoading = true
+        error = nil
+
+        let url = URL(string: "https://raw.githubusercontent.com/jaakkopasanen/AutoEq/master/results/INDEX.md")!
+
+        URLSession.shared.dataTask(with: url) { [weak self] data, response, err in
+            if let err = err {
+                DispatchQueue.main.async {
+                    self?.isLoading = false
+                    self?.error = err.localizedDescription
+                }
+                return
+            }
+
+            guard let data = data, let content = String(data: data, encoding: .utf8) else {
+                DispatchQueue.main.async {
+                    self?.isLoading = false
+                    self?.error = "Failed to decode index"
+                }
+                return
+            }
+
+            let parsed = Self.parseIndex(content)
+
+            DispatchQueue.main.async {
+                self?.isLoading = false
+                self?.entries = parsed
+                self?.lastFetchDate = Date()
+                self?.saveCache(content)
+            }
+        }.resume()
+    }
+
+    static func parseIndex(_ content: String) -> [AutoEQEntry] {
+        let lines = content.components(separatedBy: "\n")
+        var results: [AutoEQEntry] = []
+
+        let pattern = #"^- \[(.+?)\]\(\./(.+?)\) by (.+?)(?:\s+on .+)?$"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+
+        for line in lines {
+            let nsLine = line as NSString
+            guard let match = regex.firstMatch(in: line, range: NSRange(location: 0, length: nsLine.length)) else { continue }
+
+            let name = nsLine.substring(with: match.range(at: 1))
+            let rawPath = nsLine.substring(with: match.range(at: 2))
+            let source = nsLine.substring(with: match.range(at: 3))
+            let path = rawPath.removingPercentEncoding ?? rawPath
+
+            results.append(AutoEQEntry(name: name, path: path, source: source))
+        }
+
+        return results
+    }
+
+    private func loadCache() -> [AutoEQEntry]? {
+        guard let data = try? Data(contentsOf: cacheURL),
+              let content = String(data: data, encoding: .utf8) else { return nil }
+        let parsed = Self.parseIndex(content)
+        guard !parsed.isEmpty else { return nil }
+        lastFetchDate = (try? FileManager.default.attributesOfItem(atPath: cacheURL.path)[.modificationDate]) as? Date
+        return parsed
+    }
+
+    private func saveCache(_ content: String) {
+        try? content.data(using: .utf8)?.write(to: cacheURL, options: .atomic)
+    }
+}

--- a/apps/mac/RadioformApp/Sources/Services/AutoEQParser.swift
+++ b/apps/mac/RadioformApp/Sources/Services/AutoEQParser.swift
@@ -1,7 +1,6 @@
 import Foundation
 
-/// Parses AutoEQ ParametricEQ.txt files into Radioform EQPresets.
-/// Supports files from AutoEQ (GitHub), squig.link, and Equalizer APO format.
+/// Parse AutoEQ ParametricEQ.txt files into EQPresets
 enum AutoEQParser {
 
     enum ParseError: LocalizedError {
@@ -18,11 +17,15 @@ enum AutoEQParser {
         }
     }
 
-    /// Parse an AutoEQ .txt file and return an EQPreset.
-    /// - Parameters:
-    ///   - content: Raw text content of the file
-    ///   - name: Preset name (typically derived from filename)
-    /// - Returns: A valid EQPreset ready to save/apply
+    // MARK: - Cached Regexes
+
+    private static let preampRegex = try? NSRegularExpression(
+        pattern: #"^Preamp:\s*([-\d.]+)\s*dB"#
+    )
+    private static let filterRegex = try? NSRegularExpression(
+        pattern: #"^Filter\s+\d+:\s+(ON|OFF)\s+(\S+)\s+Fc\s+([\d.]+)\s+Hz\s+Gain\s+([-\d.]+)\s+dB(?:\s+Q\s+([\d.]+))?"#
+    )
+
     static func parse(content: String, name: String) throws -> EQPreset {
         let lines = content
             .replacingOccurrences(of: "\r\n", with: "\n")
@@ -46,64 +49,46 @@ enum AutoEQParser {
         guard !bands.isEmpty else { throw ParseError.noFiltersFound }
         guard bands.count <= 20 else { throw ParseError.tooManyFilters }
 
-        // If more than 10 bands, keep the 10 with the highest impact (absolute gain)
+        // Keep top 10 bands by impact if file has more
         if bands.count > 10 {
             bands.sort { abs($0.gainDb) > abs($1.gainDb) }
             bands = Array(bands.prefix(10))
-            // Re-sort by frequency for consistent display
             bands.sort { $0.frequencyHz < $1.frequencyHz }
         }
 
-        // Clamp preamp to Radioform's range
         preampDb = max(-12.0, min(12.0, preampDb))
 
-        // Truncate name to 64 chars
-        let presetName = String(name.prefix(64))
-
         return EQPreset(
-            name: presetName,
+            name: String(name.prefix(64)),
             bands: bands,
             preampDb: preampDb,
             limiterEnabled: true,
-            limiterThresholdDb: -0.1
+            limiterThresholdDb: -1.0
         )
     }
 
-    // MARK: - Line Parsers
+    // MARK: - Private
 
-    /// Parse "Preamp: -6.4 dB" → Float
     private static func parsePreampLine(_ line: String) -> Float? {
-        let pattern = #"^Preamp:\s*([-\d.]+)\s*dB"#
-        guard let match = line.range(of: pattern, options: .regularExpression) else { return nil }
-        let matched = String(line[match])
-        // Extract the number
-        let numPattern = #"[-\d.]+"#
-        guard let numRange = matched.range(of: numPattern, options: .regularExpression) else { return nil }
-        return Float(String(matched[numRange]))
+        guard let regex = preampRegex else { return nil }
+        let nsLine = line as NSString
+        guard let match = regex.firstMatch(in: line, range: NSRange(location: 0, length: nsLine.length)) else { return nil }
+        let range = match.range(at: 1)
+        guard range.location != NSNotFound else { return nil }
+        return Float(nsLine.substring(with: range))
     }
 
-    /// Parse "Filter 1: ON PK Fc 105 Hz Gain 6.5 dB Q 0.70" → EQBand
     private static func parseFilterLine(_ line: String) -> EQBand? {
-        let pattern = #"^Filter\s+\d+:\s+(ON|OFF)\s+(\S+)\s+Fc\s+([\d.]+)\s+Hz\s+Gain\s+([-\d.]+)\s+dB(?:\s+Q\s+([\d.]+))?"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+        guard let regex = filterRegex else { return nil }
         let nsLine = line as NSString
         guard let match = regex.firstMatch(in: line, range: NSRange(location: 0, length: nsLine.length)) else { return nil }
 
-        // Group 1: ON/OFF
-        let enabledStr = nsLine.substring(with: match.range(at: 1))
-        let enabled = enabledStr == "ON"
-
-        // Group 2: Filter type
-        let typeStr = nsLine.substring(with: match.range(at: 2))
-        let filterType = mapFilterType(typeStr)
-
-        // Group 3: Frequency
+        let enabled = nsLine.substring(with: match.range(at: 1)) == "ON"
+        let filterType = mapFilterType(nsLine.substring(with: match.range(at: 2)))
         guard let freq = Float(nsLine.substring(with: match.range(at: 3))) else { return nil }
-
-        // Group 4: Gain
         guard let gain = Float(nsLine.substring(with: match.range(at: 4))) else { return nil }
 
-        // Group 5: Q (optional, default 0.707 for shelf filters, 1.0 for peak)
+        // Q is optional — default 0.707 for shelves, 1.0 for peak
         var q: Float = filterType == .peak ? 1.0 : 0.707
         if match.range(at: 5).location != NSNotFound {
             if let parsedQ = Float(nsLine.substring(with: match.range(at: 5))) {
@@ -111,21 +96,15 @@ enum AutoEQParser {
             }
         }
 
-        // Clamp to Radioform's valid ranges
-        let clampedFreq = max(20.0, min(20000.0, freq))
-        let clampedGain = max(-12.0, min(12.0, gain))
-        let clampedQ = max(0.1, min(10.0, q))
-
         return EQBand(
-            frequencyHz: clampedFreq,
-            gainDb: clampedGain,
-            qFactor: clampedQ,
+            frequencyHz: max(20.0, min(20000.0, freq)),
+            gainDb: max(-12.0, min(12.0, gain)),
+            qFactor: max(0.1, min(10.0, q)),
             filterType: filterType,
             enabled: enabled
         )
     }
 
-    /// Map AutoEQ filter type strings to Radioform FilterType
     private static func mapFilterType(_ type: String) -> FilterType {
         switch type.uppercased() {
         case "PK", "PEQ", "MODAL":

--- a/apps/mac/RadioformApp/Sources/Services/AutoEQParser.swift
+++ b/apps/mac/RadioformApp/Sources/Services/AutoEQParser.swift
@@ -1,0 +1,149 @@
+import Foundation
+
+/// Parses AutoEQ ParametricEQ.txt files into Radioform EQPresets.
+/// Supports files from AutoEQ (GitHub), squig.link, and Equalizer APO format.
+enum AutoEQParser {
+
+    enum ParseError: LocalizedError {
+        case emptyFile
+        case noFiltersFound
+        case tooManyFilters
+
+        var errorDescription: String? {
+            switch self {
+            case .emptyFile: return "File is empty"
+            case .noFiltersFound: return "No EQ filters found in file"
+            case .tooManyFilters: return "File contains more than 20 filters"
+            }
+        }
+    }
+
+    /// Parse an AutoEQ .txt file and return an EQPreset.
+    /// - Parameters:
+    ///   - content: Raw text content of the file
+    ///   - name: Preset name (typically derived from filename)
+    /// - Returns: A valid EQPreset ready to save/apply
+    static func parse(content: String, name: String) throws -> EQPreset {
+        let lines = content
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .components(separatedBy: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+
+        guard !lines.isEmpty else { throw ParseError.emptyFile }
+
+        var preampDb: Float = 0.0
+        var bands: [EQBand] = []
+
+        for line in lines {
+            if let preamp = parsePreampLine(line) {
+                preampDb = preamp
+            } else if let band = parseFilterLine(line) {
+                bands.append(band)
+            }
+        }
+
+        guard !bands.isEmpty else { throw ParseError.noFiltersFound }
+        guard bands.count <= 20 else { throw ParseError.tooManyFilters }
+
+        // If more than 10 bands, keep the 10 with the highest impact (absolute gain)
+        if bands.count > 10 {
+            bands.sort { abs($0.gainDb) > abs($1.gainDb) }
+            bands = Array(bands.prefix(10))
+            // Re-sort by frequency for consistent display
+            bands.sort { $0.frequencyHz < $1.frequencyHz }
+        }
+
+        // Clamp preamp to Radioform's range
+        preampDb = max(-12.0, min(12.0, preampDb))
+
+        // Truncate name to 64 chars
+        let presetName = String(name.prefix(64))
+
+        return EQPreset(
+            name: presetName,
+            bands: bands,
+            preampDb: preampDb,
+            limiterEnabled: true,
+            limiterThresholdDb: -0.1
+        )
+    }
+
+    // MARK: - Line Parsers
+
+    /// Parse "Preamp: -6.4 dB" → Float
+    private static func parsePreampLine(_ line: String) -> Float? {
+        let pattern = #"^Preamp:\s*([-\d.]+)\s*dB"#
+        guard let match = line.range(of: pattern, options: .regularExpression) else { return nil }
+        let matched = String(line[match])
+        // Extract the number
+        let numPattern = #"[-\d.]+"#
+        guard let numRange = matched.range(of: numPattern, options: .regularExpression) else { return nil }
+        return Float(String(matched[numRange]))
+    }
+
+    /// Parse "Filter 1: ON PK Fc 105 Hz Gain 6.5 dB Q 0.70" → EQBand
+    private static func parseFilterLine(_ line: String) -> EQBand? {
+        let pattern = #"^Filter\s+\d+:\s+(ON|OFF)\s+(\S+)\s+Fc\s+([\d.]+)\s+Hz\s+Gain\s+([-\d.]+)\s+dB(?:\s+Q\s+([\d.]+))?"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+        let nsLine = line as NSString
+        guard let match = regex.firstMatch(in: line, range: NSRange(location: 0, length: nsLine.length)) else { return nil }
+
+        // Group 1: ON/OFF
+        let enabledStr = nsLine.substring(with: match.range(at: 1))
+        let enabled = enabledStr == "ON"
+
+        // Group 2: Filter type
+        let typeStr = nsLine.substring(with: match.range(at: 2))
+        let filterType = mapFilterType(typeStr)
+
+        // Group 3: Frequency
+        guard let freq = Float(nsLine.substring(with: match.range(at: 3))) else { return nil }
+
+        // Group 4: Gain
+        guard let gain = Float(nsLine.substring(with: match.range(at: 4))) else { return nil }
+
+        // Group 5: Q (optional, default 0.707 for shelf filters, 1.0 for peak)
+        var q: Float = filterType == .peak ? 1.0 : 0.707
+        if match.range(at: 5).location != NSNotFound {
+            if let parsedQ = Float(nsLine.substring(with: match.range(at: 5))) {
+                q = parsedQ
+            }
+        }
+
+        // Clamp to Radioform's valid ranges
+        let clampedFreq = max(20.0, min(20000.0, freq))
+        let clampedGain = max(-12.0, min(12.0, gain))
+        let clampedQ = max(0.1, min(10.0, q))
+
+        return EQBand(
+            frequencyHz: clampedFreq,
+            gainDb: clampedGain,
+            qFactor: clampedQ,
+            filterType: filterType,
+            enabled: enabled
+        )
+    }
+
+    /// Map AutoEQ filter type strings to Radioform FilterType
+    private static func mapFilterType(_ type: String) -> FilterType {
+        switch type.uppercased() {
+        case "PK", "PEQ", "MODAL":
+            return .peak
+        case "LS", "LSC", "LSQ", "LS 6DB", "LS 12DB":
+            return .lowShelf
+        case "HS", "HSC", "HSQ", "HS 6DB", "HS 12DB":
+            return .highShelf
+        case "LP", "LPQ":
+            return .lowPass
+        case "HP", "HPQ":
+            return .highPass
+        case "NO":
+            return .notch
+        case "BP":
+            return .bandPass
+        default:
+            return .peak
+        }
+    }
+}

--- a/apps/mac/RadioformApp/Sources/Services/PresetManager.swift
+++ b/apps/mac/RadioformApp/Sources/Services/PresetManager.swift
@@ -638,6 +638,32 @@ class PresetManager: ObservableObject {
         isEditingPresetName = false
     }
 
+    /// Import an AutoEQ .txt file as a user preset
+    func importAutoEQ(from url: URL) throws -> EQPreset {
+        let content = try String(contentsOf: url, encoding: .utf8)
+
+        // Derive preset name from filename (strip extension)
+        let baseName = url.deletingPathExtension().lastPathComponent
+            // Clean up common AutoEQ suffixes
+            .replacingOccurrences(of: " ParametricEQ", with: "")
+            .replacingOccurrences(of: " Filters", with: "")
+            .replacingOccurrences(of: "ParametricEQ", with: "Imported")
+            .trimmingCharacters(in: .whitespaces)
+        let name = baseName.isEmpty ? "Imported EQ" : baseName
+        let uniqueName = generateUniqueName(name)
+
+        let preset = try AutoEQParser.parse(content: content, name: uniqueName)
+
+        // Save as user preset
+        try savePreset(preset)
+
+        // Return the saved version (reloaded with fresh UUID)
+        if let saved = userPresets.first(where: { $0.name == uniqueName }) {
+            return saved
+        }
+        return preset
+    }
+
     /// Sanitize filename (remove invalid characters)
     private func sanitizeFilename(_ name: String) -> String {
         var safe = name.replacingOccurrences(of: "/", with: "-")

--- a/apps/mac/RadioformApp/Sources/Views/MenuBarView.swift
+++ b/apps/mac/RadioformApp/Sources/Views/MenuBarView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UniformTypeIdentifiers
 
 // Cache font lookup once at launch
 private let radioformFont: Font = {
@@ -384,7 +385,7 @@ struct PresetList: View {
     let userPresetIDs: Set<EQPreset.ID>
     let onSelect: (EQPreset) -> Void
     let onDelete: (EQPreset) -> Void
-    
+
     // Max items to show before scrolling (each item ~40px + 2px spacing)
     private let maxVisibleItems = 13
     private let estimatedItemHeight: CGFloat = 40
@@ -405,9 +406,80 @@ struct PresetList: View {
                         onDelete: onDelete
                     )
                 }
+
+                ImportAutoEQButton(onImport: { preset in
+                    onSelect(preset)
+                })
             }
         }
         .frame(maxHeight: presets.count > maxVisibleItems ? maxHeight : nil)
+    }
+}
+
+struct ImportAutoEQButton: View {
+    let onImport: (EQPreset) -> Void
+    @State private var isHovered = false
+    @State private var importError: String?
+
+    var body: some View {
+        Button {
+            importFile()
+        } label: {
+            HStack(spacing: 10) {
+                ZStack {
+                    Circle()
+                        .fill(Color(NSColor.separatorColor).opacity(0.4))
+                        .frame(width: 28, height: 28)
+
+                    Image(systemName: "square.and.arrow.down")
+                        .font(.system(size: 13, weight: .medium))
+                        .symbolRenderingMode(.hierarchical)
+                        .foregroundStyle(.secondary)
+                }
+
+                Text(importError ?? "Import AutoEQ")
+                    .font(.system(size: 13))
+                    .foregroundColor(importError != nil ? .red : .primary)
+
+                Spacer()
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 4)
+            .contentShape(Rectangle())
+            .background(
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(isHovered ? Color(NSColor.separatorColor).opacity(0.5) : Color.clear)
+            )
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, 4)
+        .padding(.vertical, 2)
+        .onHover { hovering in
+            isHovered = hovering
+        }
+    }
+
+    private func importFile() {
+        importError = nil
+
+        let panel = NSOpenPanel()
+        panel.title = "Import AutoEQ Preset"
+        panel.allowedContentTypes = [.plainText]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        do {
+            let preset = try PresetManager.shared.importAutoEQ(from: url)
+            onImport(preset)
+        } catch {
+            importError = error.localizedDescription
+            // Clear error after 3 seconds
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                importError = nil
+            }
+        }
     }
 }
 

--- a/apps/mac/RadioformApp/Sources/Views/MenuBarView.swift
+++ b/apps/mac/RadioformApp/Sources/Views/MenuBarView.swift
@@ -395,73 +395,214 @@ struct PresetList: View {
     }
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: itemSpacing) {
-                ForEach(presets) { preset in
-                    MenuItemButton(
-                        preset: preset,
-                        isActive: preset.id == activeID,
-                        isCustomPreset: userPresetIDs.contains(preset.id),
-                        onSelect: { onSelect(preset) },
-                        onDelete: onDelete
-                    )
+        VStack(alignment: .leading, spacing: itemSpacing) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: itemSpacing) {
+                    ForEach(presets) { preset in
+                        MenuItemButton(
+                            preset: preset,
+                            isActive: preset.id == activeID,
+                            isCustomPreset: userPresetIDs.contains(preset.id),
+                            onSelect: { onSelect(preset) },
+                            onDelete: onDelete
+                        )
+                    }
                 }
-
-                ImportAutoEQButton(onImport: { preset in
-                    onSelect(preset)
-                })
             }
+            .frame(maxHeight: presets.count > maxVisibleItems ? maxHeight : nil)
+
+            AutoEQSection(onImport: { preset in
+                onSelect(preset)
+            })
         }
-        .frame(maxHeight: presets.count > maxVisibleItems ? maxHeight : nil)
     }
 }
 
-struct ImportAutoEQButton: View {
+struct AutoEQSection: View {
     let onImport: (EQPreset) -> Void
+    @ObservedObject private var index = AutoEQIndex.shared
+    @State private var isExpanded = false
+    @State private var searchText = ""
     @State private var isHovered = false
-    @State private var importError: String?
+    @State private var downloadingId: UUID?
+    @State private var errorMessage: String?
+    @FocusState private var isSearchFocused: Bool
+
+    private var searchResults: [AutoEQEntry] {
+        index.search(searchText)
+    }
 
     var body: some View {
-        Button {
-            importFile()
-        } label: {
-            HStack(spacing: 10) {
-                ZStack {
-                    Circle()
-                        .fill(Color(NSColor.separatorColor).opacity(0.4))
-                        .frame(width: 28, height: 28)
-
-                    Image(systemName: "square.and.arrow.down")
-                        .font(.system(size: 13, weight: .medium))
-                        .symbolRenderingMode(.hierarchical)
-                        .foregroundStyle(.secondary)
+        VStack(alignment: .leading, spacing: 2) {
+            // Toggle button
+            Button {
+                isExpanded.toggle()
+                if isExpanded {
+                    index.loadIfNeeded()
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                        isSearchFocused = true
+                    }
+                } else {
+                    searchText = ""
+                    errorMessage = nil
                 }
+            } label: {
+                HStack(spacing: 10) {
+                    ZStack {
+                        Circle()
+                            .fill(Color(NSColor.separatorColor).opacity(0.4))
+                            .frame(width: 28, height: 28)
 
-                Text(importError ?? "Import AutoEQ")
-                    .font(.system(size: 13))
-                    .foregroundColor(importError != nil ? .red : .primary)
+                        Image(systemName: "headphones")
+                            .font(.system(size: 13, weight: .medium))
+                            .symbolRenderingMode(.hierarchical)
+                            .foregroundStyle(.secondary)
+                    }
 
-                Spacer()
+                    Text("AutoEQ")
+                        .font(.system(size: 13))
+                        .foregroundColor(.primary)
+
+                    Spacer()
+
+                    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundColor(Color(NSColor.tertiaryLabelColor))
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 4)
+                .contentShape(Rectangle())
+                .background(
+                    RoundedRectangle(cornerRadius: 5, style: .continuous)
+                        .fill(isHovered ? Color(NSColor.separatorColor).opacity(0.5) : Color.clear)
+                )
             }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 4)
-            .contentShape(Rectangle())
-            .background(
-                RoundedRectangle(cornerRadius: 5, style: .continuous)
-                    .fill(isHovered ? Color(NSColor.separatorColor).opacity(0.5) : Color.clear)
-            )
+            .buttonStyle(.plain)
+            .padding(.horizontal, 4)
+            .padding(.vertical, 2)
+            .onHover { hovering in
+                isHovered = hovering
+            }
+
+            if isExpanded {
+                VStack(alignment: .leading, spacing: 4) {
+                    // Search field
+                    HStack(spacing: 6) {
+                        Image(systemName: "magnifyingglass")
+                            .font(.system(size: 11))
+                            .foregroundColor(.secondary)
+
+                        TextField("Search headphones...", text: $searchText)
+                            .textFieldStyle(.plain)
+                            .font(.system(size: 12))
+                            .focused($isSearchFocused)
+                    }
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 5)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6, style: .continuous)
+                            .fill(Color(NSColor.separatorColor).opacity(0.3))
+                    )
+                    .padding(.horizontal, 8)
+
+                    // Status / results
+                    if index.isLoading {
+                        HStack {
+                            ProgressView()
+                                .controlSize(.small)
+                            Text("Loading headphone database...")
+                                .font(.system(size: 11))
+                                .foregroundColor(.secondary)
+                        }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 4)
+                    } else if let error = errorMessage ?? index.error {
+                        Text(error)
+                            .font(.system(size: 11))
+                            .foregroundColor(.red)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 4)
+                    } else if !searchText.isEmpty {
+                        if searchResults.isEmpty {
+                            Text("No headphones found")
+                                .font(.system(size: 11))
+                                .foregroundColor(.secondary)
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 4)
+                        } else {
+                            ScrollView {
+                                VStack(alignment: .leading, spacing: 1) {
+                                    ForEach(searchResults) { entry in
+                                        AutoEQResultRow(
+                                            entry: entry,
+                                            isDownloading: downloadingId == entry.id,
+                                            onSelect: { selectEntry(entry) }
+                                        )
+                                    }
+                                }
+                            }
+                            .frame(maxHeight: 200)
+                        }
+                    } else if !index.entries.isEmpty {
+                        Text("\(index.entries.count) headphones available")
+                            .font(.system(size: 11))
+                            .foregroundColor(.secondary)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 2)
+                    }
+
+                    // Import file fallback
+                    Button {
+                        importFile()
+                    } label: {
+                        HStack(spacing: 4) {
+                            Image(systemName: "doc")
+                                .font(.system(size: 9))
+                            Text("Import from file")
+                                .font(.system(size: 10))
+                        }
+                        .foregroundColor(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 2)
+                }
+                .padding(.bottom, 4)
+            }
         }
-        .buttonStyle(.plain)
-        .padding(.horizontal, 4)
-        .padding(.vertical, 2)
-        .onHover { hovering in
-            isHovered = hovering
+    }
+
+    private func selectEntry(_ entry: AutoEQEntry) {
+        guard downloadingId == nil else { return }
+        downloadingId = entry.id
+        errorMessage = nil
+
+        Task {
+            do {
+                let content = try await index.fetchProfile(entry)
+                let uniqueName = PresetManager.shared.generateUniqueName(entry.name)
+                let preset = try AutoEQParser.parse(content: content, name: uniqueName)
+
+                await MainActor.run {
+                    try? PresetManager.shared.savePreset(preset)
+                    PresetManager.shared.loadAllPresets()
+                    downloadingId = nil
+                    if let saved = PresetManager.shared.userPresets.first(where: { $0.name == uniqueName }) {
+                        onImport(saved)
+                    }
+                    isExpanded = false
+                    searchText = ""
+                }
+            } catch {
+                await MainActor.run {
+                    downloadingId = nil
+                    errorMessage = error.localizedDescription
+                }
+            }
         }
     }
 
     private func importFile() {
-        importError = nil
-
         let panel = NSOpenPanel()
         panel.title = "Import AutoEQ Preset"
         panel.allowedContentTypes = [.plainText]
@@ -473,12 +614,60 @@ struct ImportAutoEQButton: View {
         do {
             let preset = try PresetManager.shared.importAutoEQ(from: url)
             onImport(preset)
+            isExpanded = false
+            searchText = ""
         } catch {
-            importError = error.localizedDescription
-            // Clear error after 3 seconds
-            DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-                importError = nil
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+struct AutoEQResultRow: View {
+    let entry: AutoEQEntry
+    let isDownloading: Bool
+    let onSelect: () -> Void
+    @State private var isHovered = false
+
+    var body: some View {
+        Button { onSelect() } label: {
+            HStack(spacing: 8) {
+                if isDownloading {
+                    ProgressView()
+                        .controlSize(.small)
+                        .frame(width: 14, height: 14)
+                } else {
+                    Image(systemName: "headphones")
+                        .font(.system(size: 11))
+                        .foregroundColor(.secondary)
+                        .frame(width: 14)
+                }
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(entry.name)
+                        .font(.system(size: 12))
+                        .foregroundColor(.primary)
+                        .lineLimit(1)
+
+                    Text(entry.source)
+                        .font(.system(size: 9))
+                        .foregroundColor(Color(NSColor.tertiaryLabelColor))
+                }
+
+                Spacer()
             }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .contentShape(Rectangle())
+            .background(
+                RoundedRectangle(cornerRadius: 4, style: .continuous)
+                    .fill(isHovered ? Color(NSColor.separatorColor).opacity(0.4) : Color.clear)
+            )
+        }
+        .buttonStyle(.plain)
+        .disabled(isDownloading)
+        .padding(.horizontal, 4)
+        .onHover { hovering in
+            isHovered = hovering
         }
     }
 }


### PR DESCRIPTION
## Summary

Click the AutoEQ dropdown at the bottom of presets, search for your headphones/IEMs, and pick a profile. Also includes file import for .txt files from squig.link or similar.

Values clamped to Radioform ranges. Files with >10 bands trimmed to the 10 with highest gain.

Headphone list pulled from AutoEQ's INDEX.md (~6k entries), cached locally.

## Test plan

- [ ] Search for headphones in AutoEQ panel, select one, verify it applies correctly
- [ ] Import a .txt file via "Import from file"
- [ ] Search with no network, cached results should still work
- [ ] Try a file with >10 filters, should keep top 10 by gain

Closes #58